### PR TITLE
Use PHP hash_equals() function to compare the token

### DIFF
--- a/src/Totp.php
+++ b/src/Totp.php
@@ -159,7 +159,7 @@ class Totp
         $stepEnd   = $currentStep + (int)$acceptStepFuture + 1;
         for ($testTimeStep = $stepBegin; $testTimeStep < $stepEnd; ++$testTimeStep) {
             $testValue = self::calcMain($keyBinary, $testTimeStep, $digits, $hash);
-            if ($testValue === $value) {
+            if (hash_equals($testValue, $value)) {
                 return true;
             }
         }


### PR DESCRIPTION
This avoids a possible timing attack.

[hash_equals()](https://www.php.net/manual/en/function.hash-equals.php) was introduced in PHP 5.6.